### PR TITLE
Update Multiverse-Core to 5.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.gradle/
+temp/

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
         url = 'https://repo.papermc.io/repository/maven-public/'
     }
     maven {
-        url = "https://repo.onarandombox.com/content/groups/public/"
+        url = "https://repo.onarandombox.com/multiverse-releases"
     }
 
     maven {
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT'
-    compileOnly 'com.onarandombox.multiversecore:multiverse-core:4.3.12'
+    compileOnly 'org.mvplugins.multiverse.core:multiverse-core:5.2.0'
     compileOnly 'me.clip:placeholderapi:2.11.6'
 }
 

--- a/src/main/java/studio/minekarta/kartaworldreset/KartaWorldReset.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/KartaWorldReset.java
@@ -1,6 +1,6 @@
 package studio.minekarta.kartaworldreset;
 
-import com.onarandombox.MultiverseCore.MultiverseCore;
+import org.mvplugins.multiverse.core.MultiverseCoreApi;
 import studio.minekarta.kartaworldreset.commands.Commands;
 import studio.minekarta.kartaworldreset.papi.PlaceholderView;
 import studio.minekarta.kartaworldreset.settings.Config;
@@ -14,14 +14,14 @@ import java.util.logging.Logger;
 public final class KartaWorldReset extends JavaPlugin {
 
     private static  Plugin plugin;
-    private static MultiverseCore worldManager;
+    private static MultiverseCoreApi worldManager;
     public static Logger log;
 
     @Override
     public void onEnable() {
         // Plugin startup logic
         plugin = this;
-        worldManager = (MultiverseCore) Bukkit.getPluginManager().getPlugin("Multiverse-Core");
+        worldManager = MultiverseCoreApi.get();
         log = this.getLogger();
         Config.setup();
         if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")){
@@ -36,7 +36,7 @@ public final class KartaWorldReset extends JavaPlugin {
         // Plugin shutdown logic
     }
 
-    public static MultiverseCore getWorldManager() {
+    public static MultiverseCoreApi getWorldManager() {
         return worldManager;
     }
     public static Plugin getPlugin() {

--- a/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
@@ -1,5 +1,8 @@
 package studio.minekarta.kartaworldreset.tasks;
 
+import org.mvplugins.multiverse.core.world.LoadedMultiverseWorld;
+import org.mvplugins.multiverse.core.world.MultiverseWorld;
+import org.mvplugins.multiverse.core.world.options.RegenWorldOptions;
 import studio.minekarta.kartaworldreset.KartaWorldReset;
 import studio.minekarta.kartaworldreset.settings.Config;
 import studio.minekarta.kartaworldreset.utils.Utils;
@@ -52,7 +55,12 @@ public class CountDown extends TimerTask {
                                 }
                             }
                         });
-                        KartaWorldReset.getWorldManager().getMVWorldManager().regenWorld(world, true, true, null, true);
+                        KartaWorldReset.getWorldManager().getWorldManager().getWorld(world).peek(mvWorld -> {
+                            if (mvWorld instanceof LoadedMultiverseWorld) {
+                                LoadedMultiverseWorld loadedWorld = (LoadedMultiverseWorld) mvWorld;
+                                KartaWorldReset.getWorldManager().getWorldManager().regenWorld(RegenWorldOptions.world(loadedWorld));
+                            }
+                        });
                     });
                     Bukkit.getOnlinePlayers().forEach((player -> {
                         Utils.sendTitle(player, "New Season is begin", "Prepare yourself to new adventure!", 80);


### PR DESCRIPTION
This commit updates the Multiverse-Core dependency from version 4.3.12 to 5.2.0.

The following changes were made:
- Updated the dependency in `build.gradle` to `org.mvplugins.multiverse.core:multiverse-core:5.2.0`.
- Updated the repository URL in `build.gradle` to the new Multiverse-Core releases repository.
- Updated the Java source code to be compatible with the new Multiverse-Core API. This includes changes to how the API instance is retrieved and how worlds are regenerated.
- Added a `.gitignore` file to the project to prevent build artifacts from being committed.