### PR TITLE
feat: add manual reset command and update configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KartaWorldReset Plugin v1.1.0-SNAPSHOT
+# KartaWorldReset Plugin v1.2.0-SNAPSHOT
 
 A powerful and easy-to-use plugin for automatically resetting worlds on a schedule.
 
@@ -26,6 +26,7 @@ The main command is `/kartaworldreset`, which can be aliased with `/kwr`.
 | `/kwr addworld <world>`  | Adds a world to the reset list.           | `kartaworldreset.admin` |
 | `/kwr removeworld <world>`| Removes a world from the reset list.      | `kartaworldreset.admin` |
 | `/kwr papi reload`       | Reloads the PlaceholderAPI expansion.     | `kartaworldreset.admin` |
+| `/kwr reset`             | Manually resets the worlds in the list.   | `kartaworldreset.admin` |
 
 ## Permissions
 | Permission              | Description                               |
@@ -59,7 +60,7 @@ Save:
 
 Worlds:
   # A list of worlds to be reset.
-  - world_the_end
+  - your_world
 
 Lobby:
   # The world to teleport players to before the reset.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.1.0-SNAPSHOT
+version = 1.2.0-SNAPSHOT
 serverPlugin = D:/Projects/Minecraft/TestServer/plugins

--- a/src/main/java/studio/minekarta/kartaworldreset/commands/Commands.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/commands/Commands.java
@@ -3,6 +3,7 @@ package studio.minekarta.kartaworldreset.commands;
 import me.clip.placeholderapi.PlaceholderAPI;
 import studio.minekarta.kartaworldreset.papi.PlaceholderView;
 import studio.minekarta.kartaworldreset.settings.Config;
+import studio.minekarta.kartaworldreset.utils.Reset;
 import studio.minekarta.kartaworldreset.utils.ScheduleTimer;
 import studio.minekarta.kartaworldreset.utils.Utils;
 import org.bukkit.Bukkit;
@@ -101,6 +102,14 @@ public class Commands implements CommandExecutor, TabCompleter {
                 help(sender);
                 return true;
             }
+
+            if(args[0].equalsIgnoreCase("reset")){
+                Utils.runAsPermission(sender, adminPermission, ()->{
+                    Reset.world();
+                    Config.getSettings().set();
+                }, () -> sender.sendMessage(Config.getMessages().noPermission));
+                return true;
+            }
             if(args[0].equalsIgnoreCase("autogen")){
                 Utils.runAsPermission(sender, adminPermission, ()->{
                     Config.getSettings().set();
@@ -142,6 +151,7 @@ public class Commands implements CommandExecutor, TabCompleter {
                 subcommands.add("autogen");
                 subcommands.add("addworld");
                 subcommands.add("removeworld");
+                subcommands.add("reset");
                 if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
                     subcommands.add("papi");
                 }

--- a/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
@@ -3,8 +3,11 @@ package studio.minekarta.kartaworldreset.tasks;
 import org.mvplugins.multiverse.core.world.LoadedMultiverseWorld;
 import org.mvplugins.multiverse.core.world.MultiverseWorld;
 import org.mvplugins.multiverse.core.world.options.RegenWorldOptions;
+import org.mvplugins.multiverse.core.world.LoadedMultiverseWorld;
+import org.mvplugins.multiverse.core.world.options.RegenWorldOptions;
 import studio.minekarta.kartaworldreset.KartaWorldReset;
 import studio.minekarta.kartaworldreset.settings.Config;
+import studio.minekarta.kartaworldreset.utils.Reset;
 import studio.minekarta.kartaworldreset.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
@@ -36,38 +39,12 @@ public class CountDown extends TimerTask {
             new BukkitRunnable() {
                 @Override
                 public void run() {
-                    Bukkit.getOnlinePlayers().forEach((player -> {
-                        Utils.sendTitle(player, "Resetting", "Please wait...", 200);
-                        //player.playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_GROWL, 1, 1);
-                    }));
-
-                    Config.getWorldList().getWorlds().forEach( world -> {
-                        Bukkit.getOnlinePlayers().forEach(player -> {
-                            if(player.getWorld().getName().equalsIgnoreCase(world)){
-                                if(Config.getWorldList().getLobby() != null){
-                                    player.teleport(Bukkit.getWorld(Config.getWorldList().getLobby()).getSpawnLocation());
-                                } else {
-                                    if(player.getBedSpawnLocation()!=null){
-                                        player.teleport(player.getBedSpawnLocation());
-                                    } else {
-                                        player.teleport(Bukkit.getServer().getWorlds().get(0).getSpawnLocation());
-                                    }
-                                }
-                            }
-                        });
-                        KartaWorldReset.getWorldManager().getWorldManager().getWorld(world).peek(mvWorld -> {
-                            if (mvWorld instanceof LoadedMultiverseWorld) {
-                                LoadedMultiverseWorld loadedWorld = (LoadedMultiverseWorld) mvWorld;
-                                KartaWorldReset.getWorldManager().getWorldManager().regenWorld(RegenWorldOptions.world(loadedWorld));
-                            }
-                        });
-                    });
-                    Bukkit.getOnlinePlayers().forEach((player -> {
-                        Utils.sendTitle(player, "New Season is begin", "Prepare yourself to new adventure!", 80);
-                        player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1, 1);
-                    } ));
-                }
-            }.runTask(KartaWorldReset.getPlugin());
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            Reset.world();
+                        }
+                    }.runTask(KartaWorldReset.getPlugin());
             Config.getSettings().set();
             timer.cancel();
         }

--- a/src/main/java/studio/minekarta/kartaworldreset/utils/Reset.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/utils/Reset.java
@@ -1,0 +1,43 @@
+package studio.minekarta.kartaworldreset.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.mvplugins.multiverse.core.world.LoadedMultiverseWorld;
+import org.mvplugins.multiverse.core.world.options.RegenWorldOptions;
+import studio.minekarta.kartaworldreset.KartaWorldReset;
+import studio.minekarta.kartaworldreset.settings.Config;
+
+public class Reset {
+
+    public static void world() {
+        Bukkit.getOnlinePlayers().forEach((player -> {
+            Utils.sendTitle(player, "Resetting", "Please wait...", 200);
+        }));
+
+        Config.getWorldList().getWorlds().forEach( world -> {
+            Bukkit.getOnlinePlayers().forEach(player -> {
+                if(player.getWorld().getName().equalsIgnoreCase(world)){
+                    if(Config.getWorldList().getLobby() != null){
+                        player.teleport(Bukkit.getWorld(Config.getWorldList().getLobby()).getSpawnLocation());
+                    } else {
+                        if(player.getBedSpawnLocation()!=null){
+                            player.teleport(player.getBedSpawnLocation());
+                        } else {
+                            player.teleport(Bukkit.getServer().getWorlds().get(0).getSpawnLocation());
+                        }
+                    }
+                }
+            });
+            KartaWorldReset.getWorldManager().getWorldManager().getWorld(world).peek(mvWorld -> {
+                if (mvWorld instanceof LoadedMultiverseWorld) {
+                    LoadedMultiverseWorld loadedWorld = (LoadedMultiverseWorld) mvWorld;
+                    KartaWorldReset.getWorldManager().getWorldManager().regenWorld(RegenWorldOptions.world(loadedWorld));
+                }
+            });
+        });
+        Bukkit.getOnlinePlayers().forEach((player -> {
+            Utils.sendTitle(player, "New Season is begin", "Prepare yourself to new adventure!", 80);
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1, 1);
+        } ));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,7 @@ Save :
   nextReset : null
 
 Worlds :
-  - world_the_end
+  - your_world
 
 Lobby :
   # set null for teleport to bed or main world.


### PR DESCRIPTION
- Add a new `reset` command to manually trigger a world reset.
- Change the default world in the configuration to `your_world`.
- Update the plugin version to `1.2.0-SNAPSHOT`.
- Update `README.md` to reflect the changes.