### PR TITLE
Fix compilation error in CountDown.java

### DIFF
--- a/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
+++ b/src/main/java/studio/minekarta/kartaworldreset/tasks/CountDown.java
@@ -45,8 +45,10 @@ public class CountDown extends TimerTask {
                             Reset.world();
                         }
                     }.runTask(KartaWorldReset.getPlugin());
-            Config.getSettings().set();
-            timer.cancel();
+                    Config.getSettings().set();
+                    timer.cancel();
+                }
+            }.runTask(KartaWorldReset.getPlugin());
         }
     }
 }


### PR DESCRIPTION
This commit fixes a compilation error in `CountDown.java` caused by missing closing braces and a missing method call. The code has been corrected to ensure the `BukkitRunnable` is properly executed.